### PR TITLE
Update composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=5.3.7",
-        "illuminate/support": "4.1.*"
+        "illuminate/support": "4.2.*"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
You should change the required illuminate support to 4.2 in order to be able to install it in Laravel 4.2. I believe it should be compatible since there weren't many changes in the core.
